### PR TITLE
Specify Node.js 18.x engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "url": "https://github.com/cobidev/simplefolio/issues"
   },
   "homepage": "https://github.com/cobidev/simplefolio#readme",
+  "engines": {
+    "node": "18.x"
+  },
   "devDependencies": {
     "@parcel/transformer-sass": "^2.0.1",
     "parcel": "^2.0.1",


### PR DESCRIPTION
## Summary
- declare a Node.js 18.x engine requirement in package.json to align Vercel builds with a compatible runtime

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8b16f3d188324b5c242216769231a