### PR TITLE
chore: update Node engine for Vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/cobidev/simplefolio#readme",
   "engines": {
-    "node": "18.x"
+    "node": "22.x"
   },
   "devDependencies": {
     "@parcel/transformer-sass": "^2.0.1",


### PR DESCRIPTION
## Summary
- update the package.json engines field to request Node.js 22 for Vercel builds

## Testing
- `npm ci --no-progress --loglevel error` *(fails: npm registry requests return 403 Forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8bac61ccc8324b2b6b15b3436d6f8